### PR TITLE
Fix enrollment billing changes for future invoices

### DIFF
--- a/internal/app/invoice/service.go
+++ b/internal/app/invoice/service.go
@@ -466,20 +466,32 @@ func (s *Service) rebuildDraftForStudentInStore(ctx context.Context, studentID, 
 				return res, err
 			}
 		} else if err == nil && isCurrentEditableMonth(y, m) && existing.Status != StatusCanceled {
+			pdfRef, err := s.invoicePDFRef(existing)
+			if err != nil {
+				return res, err
+			}
 			if _, err := s.db.InvoiceLine.Delete().Where(invoiceline.InvoiceIDEQ(existing.ID)).Exec(ctx); err != nil {
 				return res, err
 			}
-			update := existing.Update().SetTotalAmountCents(0)
+			update := existing.Update().
+				SetTotalAmountCents(0).
+				SetEmailDeliveryStatus(invoice.EmailDeliveryStatusNotSent).
+				ClearPdfFilename().
+				ClearPdfRevision().
+				ClearPdfGeneratedAt().
+				ClearLastEmailedAt().
+				ClearLastEmailedTo().
+				ClearLastEmailedRevision().
+				ClearLastEmailError().
+				ClearLastEmailFailedAt()
 			if existing.Status != StatusDraft {
-				update = update.ClearPdfRevision().ClearPdfGeneratedAt()
+				update = update.SetStatus(StatusDraft).ClearNumber()
 			}
 			if _, err := update.Save(ctx); err != nil {
 				return res, err
 			}
-			if existing.Status != StatusDraft {
-				if err := paysvc.New(s.db).RecomputeInvoiceStatus(ctx, existing.ID); err != nil {
-					return res, err
-				}
+			if existing.Status != StatusDraft && pdfRef != nil {
+				res.pdfsToInvalidate = append(res.pdfsToInvalidate, *pdfRef)
 			}
 			res.stats.Updated++
 		}

--- a/internal/app/invoice/service_test.go
+++ b/internal/app/invoice/service_test.go
@@ -908,6 +908,134 @@ func TestGenerateDraftsDeletesExistingZeroDraft(t *testing.T) {
 	}
 }
 
+func TestGenerateDraftsReopensCurrentMonthZeroIssuedInvoiceToDraft(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:invoice-zero-issued-to-draft?mode=memory&_fk=1")
+	defer client.Close()
+
+	setInvoiceCurrentTime(t, time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC))
+	tmpDir := t.TempDir()
+	svc := NewWithInvoicesDir(client, tmpDir)
+
+	st, err := client.Student.Create().
+		SetFullName("Zero Current Student").
+		SetEmail("family@example.com").
+		SetIsActive(true).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("Student.Create: %v", err)
+	}
+
+	crs, err := client.Course.Create().
+		SetName("Keramika").
+		SetType(course.TypeGroup).
+		SetLessonPriceCents(money.EurosToCents(25)).
+		SetSubscriptionPriceCents(0).
+		SetIsActive(true).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("Course.Create: %v", err)
+	}
+
+	enr, err := client.Enrollment.Create().
+		SetStudentID(st.ID).
+		SetCourseID(crs.ID).
+		SetBillingMode(enrollment.BillingModePerLesson).
+		SetDiscountPct(0).
+		SetNote("").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("Enrollment.Create: %v", err)
+	}
+
+	number := "LS-202606-009"
+	iv, err := client.Invoice.Create().
+		SetStudentID(st.ID).
+		SetPeriodYear(2026).
+		SetPeriodMonth(6).
+		SetStatus(StatusPaidPendingPDF).
+		SetNumber(number).
+		SetTotalAmountCents(money.EurosToCents(25)).
+		SetPdfFilename(number + ".pdf").
+		SetPdfRevision(2).
+		SetPdfGeneratedAt(time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)).
+		SetEmailDeliveryStatus(invoice.EmailDeliveryStatusSent).
+		SetLastEmailedAt(time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)).
+		SetLastEmailedTo("family@example.com").
+		SetLastEmailedRevision(2).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("Invoice.Create: %v", err)
+	}
+
+	if _, err := client.InvoiceLine.Create().
+		SetInvoiceID(iv.ID).
+		SetEnrollmentID(enr.ID).
+		SetDescription("Dalības maksa par Keramika").
+		SetQty(1).
+		SetUnitPriceCents(money.EurosToCents(25)).
+		SetAmountCents(money.EurosToCents(25)).
+		Save(ctx); err != nil {
+		t.Fatalf("InvoiceLine.Create: %v", err)
+	}
+
+	pdfPath := PDFPathByNumberAndName(tmpDir, 2026, 6, number, st.FullName)
+	if err := os.MkdirAll(filepath.Dir(pdfPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pdfPath, []byte("demo"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	res, err := svc.GenerateDrafts(ctx, 2026, 6)
+	if err != nil {
+		t.Fatalf("GenerateDrafts: %v", err)
+	}
+	if res.Created != 0 || res.Updated != 1 || res.SkippedNoLines != 1 || res.SkippedHasInvoice != 0 {
+		t.Fatalf("unexpected GenerateDrafts result: %+v", res)
+	}
+
+	got, err := client.Invoice.Get(ctx, iv.ID)
+	if err != nil {
+		t.Fatalf("Invoice.Get: %v", err)
+	}
+	if got.Status != StatusDraft {
+		t.Fatalf("Status = %q, want %q", got.Status, StatusDraft)
+	}
+	if got.Number != nil {
+		t.Fatalf("Number = %v, want nil", got.Number)
+	}
+	if got.PdfFilename != nil || got.PdfRevision != nil || got.PdfGeneratedAt != nil {
+		t.Fatalf("expected PDF metadata cleared, got filename=%v revision=%v generatedAt=%v", got.PdfFilename, got.PdfRevision, got.PdfGeneratedAt)
+	}
+	if got.EmailDeliveryStatus != invoice.EmailDeliveryStatusNotSent {
+		t.Fatalf("EmailDeliveryStatus = %q, want %q", got.EmailDeliveryStatus, invoice.EmailDeliveryStatusNotSent)
+	}
+	if got.LastEmailedAt != nil || got.LastEmailedTo != nil || got.LastEmailedRevision != nil || got.LastEmailError != nil || got.LastEmailFailedAt != nil {
+		t.Fatalf(
+			"expected email metadata cleared, got lastEmailedAt=%v lastEmailedTo=%v lastEmailedRevision=%v lastEmailError=%v lastEmailFailedAt=%v",
+			got.LastEmailedAt,
+			got.LastEmailedTo,
+			got.LastEmailedRevision,
+			got.LastEmailError,
+			got.LastEmailFailedAt,
+		)
+	}
+	if got.TotalAmountCents != 0 {
+		t.Fatalf("TotalAmountCents = %d, want 0", got.TotalAmountCents)
+	}
+	lineCount, err := client.InvoiceLine.Query().Where(invoiceline.InvoiceIDEQ(iv.ID)).Count(ctx)
+	if err != nil {
+		t.Fatalf("InvoiceLine.Count: %v", err)
+	}
+	if lineCount != 0 {
+		t.Fatalf("invoice line count = %d, want 0", lineCount)
+	}
+	if _, err := os.Stat(pdfPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pdf removed, stat err=%v", err)
+	}
+}
+
 func TestRebuildStudentDraft(t *testing.T) {
 	ctx := context.Background()
 	client := enttest.Open(t, "sqlite3", "file:invoice-rebuild-student-draft?mode=memory&_fk=1")

--- a/internal/backend/service_enrollments.go
+++ b/internal/backend/service_enrollments.go
@@ -8,8 +8,11 @@ import (
 
 	"langschool/ent"
 	"langschool/ent/enrollment"
+	entinvoice "langschool/ent/invoice"
 	"langschool/internal/money"
 )
+
+var enrollmentCurrentTime = time.Now
 
 func (s *Service) EnrollmentList(ctx context.Context, studentID *int, courseID *int) ([]EnrollmentDTO, error) {
 	q := s.rt.DB.Ent.Enrollment.Query().
@@ -140,7 +143,7 @@ func (s *Service) EnrollmentUpdate(ctx context.Context, enrollmentID int, billin
 	if err != nil {
 		return nil, err
 	}
-	if err := s.rebuildCurrentMonthInvoiceForEnrollmentChange(ctx, before.StudentID, before.ChargeMaterials != chargeMaterials); err != nil {
+	if err := s.rebuildInvoiceForEnrollmentChange(ctx, before, billingMode, chargeMaterials, lessonPriceOverride, subscriptionLessonPrice); err != nil {
 		return nil, err
 	}
 	dto := toEnrollmentDTO(item)
@@ -192,23 +195,111 @@ func (s *Service) EnrollmentUpdateWithVersion(ctx context.Context, enrollmentID,
 	if err != nil {
 		return nil, err
 	}
-	if err := s.rebuildCurrentMonthInvoiceForEnrollmentChange(ctx, before.StudentID, before.ChargeMaterials != chargeMaterials); err != nil {
+	if err := s.rebuildInvoiceForEnrollmentChange(ctx, before, billingMode, chargeMaterials, lessonPriceOverride, subscriptionLessonPrice); err != nil {
 		return nil, err
 	}
 	dto := toEnrollmentDTO(item)
 	return &dto, nil
 }
 
-func (s *Service) rebuildCurrentMonthInvoiceForEnrollmentChange(ctx context.Context, studentID int, materialsChanged bool) error {
-	if !materialsChanged {
+func (s *Service) rebuildInvoiceForEnrollmentChange(ctx context.Context, before *ent.Enrollment, billingMode string, chargeMaterials bool, lessonPriceOverride, subscriptionLessonPrice float64) error {
+	if before == nil || !enrollmentInvoiceAffectingFieldsChanged(before, billingMode, chargeMaterials, lessonPriceOverride, subscriptionLessonPrice) {
 		return nil
 	}
-	if s.rt == nil || s.rt.Invoice == nil {
+	if s.rt == nil || s.rt.Invoice == nil || s.rt.DB.Ent == nil {
 		return nil
 	}
-	now := time.Now()
-	_, err := s.rt.Invoice.RebuildStudentDraft(ctx, studentID, now.Year(), int(now.Month()))
+	year, month, err := s.resolveEnrollmentInvoiceRebuildMonth(ctx, before.StudentID)
+	if err != nil {
+		return err
+	}
+	existing, err := s.rt.DB.Ent.Invoice.Query().
+		Where(
+			entinvoice.StudentIDEQ(before.StudentID),
+			entinvoice.PeriodYearEQ(year),
+			entinvoice.PeriodMonthEQ(month),
+		).
+		Only(ctx)
+	if ent.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if existing.Status != entinvoice.StatusDraft {
+		return nil
+	}
+	_, err = s.rt.Invoice.RebuildStudentDraft(ctx, before.StudentID, year, month)
 	return err
+}
+
+func (s *Service) resolveEnrollmentInvoiceRebuildMonth(ctx context.Context, studentID int) (int, int, error) {
+	now := enrollmentCurrentTime()
+	year, month := now.Year(), int(now.Month())
+	if s.rt == nil || s.rt.DB.Ent == nil {
+		return year, month, nil
+	}
+	currentInvoice, err := s.rt.DB.Ent.Invoice.Query().
+		Where(
+			entinvoice.StudentIDEQ(studentID),
+			entinvoice.PeriodYearEQ(year),
+			entinvoice.PeriodMonthEQ(month),
+		).
+		Only(ctx)
+	if ent.IsNotFound(err) {
+		return year, month, nil
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	if invoiceLocksEnrollmentChangesToNextMonth(currentInvoice.Status) {
+		nextYear, nextMonth := nextBillingMonth(year, month)
+		return nextYear, nextMonth, nil
+	}
+	return year, month, nil
+}
+
+func enrollmentInvoiceAffectingFieldsChanged(before *ent.Enrollment, billingMode string, chargeMaterials bool, lessonPriceOverride, subscriptionLessonPrice float64) bool {
+	if before == nil {
+		return false
+	}
+	nextLessonPriceOverrideCents := normalizedLessonPriceOverrideCents(billingMode, lessonPriceOverride)
+	nextSubscriptionLessonPriceCents := normalizedSubscriptionLessonPriceCents(billingMode, subscriptionLessonPrice)
+	return before.BillingMode != enrollment.BillingMode(billingMode) ||
+		before.ChargeMaterials != chargeMaterials ||
+		before.LessonPriceOverrideCents != nextLessonPriceOverrideCents ||
+		before.SubscriptionLessonPriceCents != nextSubscriptionLessonPriceCents
+}
+
+func normalizedLessonPriceOverrideCents(billingMode string, lessonPriceOverride float64) int64 {
+	if billingMode != BillingModePerLesson {
+		return -1
+	}
+	if lessonPriceOverride == 0 {
+		return -1
+	}
+	return money.EurosToCents(lessonPriceOverride)
+}
+
+func normalizedSubscriptionLessonPriceCents(billingMode string, subscriptionLessonPrice float64) int64 {
+	if billingMode != BillingModeSubscription {
+		return 0
+	}
+	return money.EurosToCents(subscriptionLessonPrice)
+}
+
+func invoiceLocksEnrollmentChangesToNextMonth(status entinvoice.Status) bool {
+	return status == entinvoice.StatusIssued ||
+		status == entinvoice.StatusIssuedPendingPdf ||
+		status == entinvoice.StatusPaid ||
+		status == entinvoice.StatusPaidPendingPdf
+}
+
+func nextBillingMonth(year, month int) (int, int) {
+	if month == 12 {
+		return year + 1, 1
+	}
+	return year, month + 1
 }
 
 func toEnrollmentDTO(e *ent.Enrollment) EnrollmentDTO {

--- a/internal/backend/service_enrollments_test.go
+++ b/internal/backend/service_enrollments_test.go
@@ -1,0 +1,95 @@
+package backend
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"langschool/ent"
+	"langschool/ent/enrollment"
+	entinvoice "langschool/ent/invoice"
+	"langschool/internal/money"
+	appruntime "langschool/internal/runtime"
+)
+
+func setEnrollmentCurrentTime(t *testing.T, ts time.Time) {
+	t.Helper()
+	previous := enrollmentCurrentTime
+	enrollmentCurrentTime = func() time.Time { return ts }
+	t.Cleanup(func() {
+		enrollmentCurrentTime = previous
+	})
+}
+
+func newTestEnrollmentService(t *testing.T) *Service {
+	t.Helper()
+	root := t.TempDir()
+	rt, err := appruntime.Start(context.Background(), appruntime.Config{
+		BaseDir:       filepath.Join(root, "base"),
+		DataDir:       filepath.Join(root, "data"),
+		BackupsDir:    filepath.Join(root, "backups"),
+		InvoicesDir:   filepath.Join(root, "invoices"),
+		ExportsDir:    filepath.Join(root, "exports"),
+		FontsDir:      filepath.Join(root, "fonts"),
+		AdminUsername: "admin",
+		AdminPassword: "test-password-123",
+		SessionSecret: "test-session-secret",
+	})
+	if err != nil {
+		t.Fatalf("runtime.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = rt.Close()
+	})
+	return New(rt)
+}
+
+func TestResolveEnrollmentInvoiceRebuildMonthRollsDecemberToJanuary(t *testing.T) {
+	setEnrollmentCurrentTime(t, time.Date(2026, 12, 20, 10, 0, 0, 0, time.UTC))
+
+	svc := newTestEnrollmentService(t)
+	ctx := context.Background()
+
+	st, err := svc.rt.DB.Ent.Student.Create().
+		SetFullName("Year Boundary Student").
+		SetIsActive(true).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("Student.Create: %v", err)
+	}
+
+	if _, err := svc.rt.DB.Ent.Invoice.Create().
+		SetStudentID(st.ID).
+		SetPeriodYear(2026).
+		SetPeriodMonth(12).
+		SetStatus(entinvoice.StatusIssued).
+		SetNumber("LS-202612-001").
+		SetTotalAmountCents(money.EurosToCents(25)).
+		Save(ctx); err != nil {
+		t.Fatalf("Invoice.Create: %v", err)
+	}
+
+	year, month, err := svc.resolveEnrollmentInvoiceRebuildMonth(ctx, st.ID)
+	if err != nil {
+		t.Fatalf("resolveEnrollmentInvoiceRebuildMonth: %v", err)
+	}
+	if year != 2027 || month != 1 {
+		t.Fatalf("resolved month = %04d-%02d, want 2027-01", year, month)
+	}
+}
+
+func TestEnrollmentInvoiceAffectingFieldsChangedIgnoresNoteOnlyEdits(t *testing.T) {
+	before := &ent.Enrollment{
+		BillingMode:                  enrollment.BillingModePerLesson,
+		ChargeMaterials:              true,
+		LessonPriceOverrideCents:     money.EurosToCents(12.5),
+		SubscriptionLessonPriceCents: 0,
+		Note:                         "before",
+	}
+
+	changed := enrollmentInvoiceAffectingFieldsChanged(before, BillingModePerLesson, true, 12.5, 0)
+	if changed {
+		t.Fatal("expected note-only edit to be ignored")
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1007,7 +1007,7 @@ func TestCurrentMonthInvoiceStaysLiveAfterFullPayment(t *testing.T) {
 	}
 }
 
-func TestEnrollmentChargeMaterialsRebuildsCurrentMonthInvoiceOnly(t *testing.T) {
+func TestEnrollmentChargeMaterialsRebuildsCurrentMonthDraftOnly(t *testing.T) {
 	env := newTestServer(t)
 	defer env.Close()
 
@@ -1102,6 +1102,199 @@ func TestEnrollmentChargeMaterialsRebuildsCurrentMonthInvoiceOnly(t *testing.T) 
 		if line.Description == "Mācību materiāli" {
 			t.Fatal("current invoice still has materials line after toggle off")
 		}
+	}
+}
+
+func TestEnrollmentChargeMaterialsDefersToNextMonthDraftWhenCurrentMonthIssued(t *testing.T) {
+	env := newTestServer(t)
+	defer env.Close()
+
+	now := time.Now()
+	currentYear, currentMonth := now.Year(), int(now.Month())
+	nextYear, nextMonth := currentYear, currentMonth+1
+	if nextMonth == 13 {
+		nextMonth = 1
+		nextYear++
+	}
+
+	st := postJSON[backend.StudentDTO](t, env.Client, env.Server.URL, "/api/students", map[string]any{"fullName": "Future Month Student"})
+	course := postJSON[backend.CourseDTO](t, env.Client, env.Server.URL, "/api/courses", map[string]any{
+		"name":              "Future Month Course",
+		"type":              "group",
+		"lessonPrice":       20,
+		"subscriptionPrice": 0,
+	})
+	enr := postJSON[backend.EnrollmentDTO](t, env.Client, env.Server.URL, "/api/enrollments", map[string]any{
+		"studentId":           st.ID,
+		"courseId":            course.ID,
+		"billingMode":         "per_lesson",
+		"chargeMaterials":     true,
+		"lessonPriceOverride": 0,
+		"note":                "",
+	})
+
+	putJSON[map[string]bool](t, env.Client, env.Server.URL, "/api/attendance", map[string]any{
+		"studentId": st.ID,
+		"courseId":  course.ID,
+		"year":      currentYear,
+		"month":     currentMonth,
+		"hours":     1.0,
+	})
+	putJSON[map[string]bool](t, env.Client, env.Server.URL, "/api/attendance", map[string]any{
+		"studentId": st.ID,
+		"courseId":  course.ID,
+		"year":      nextYear,
+		"month":     nextMonth,
+		"hours":     1.0,
+	})
+	postJSON[map[string]any](t, env.Client, env.Server.URL, "/api/invoices/generate-drafts", map[string]any{
+		"year":  currentYear,
+		"month": currentMonth,
+	})
+	postJSON[map[string]any](t, env.Client, env.Server.URL, "/api/invoices/generate-drafts", map[string]any{
+		"year":  nextYear,
+		"month": nextMonth,
+	})
+
+	currentInvoices := getJSON[[]backend.InvoiceListItem](t, env.Client, env.Server.URL, "/api/invoices?year="+strconv.Itoa(currentYear)+"&month="+strconv.Itoa(currentMonth)+"&status=all")
+	nextInvoices := getJSON[[]backend.InvoiceListItem](t, env.Client, env.Server.URL, "/api/invoices?year="+strconv.Itoa(nextYear)+"&month="+strconv.Itoa(nextMonth)+"&status=all")
+	if len(currentInvoices) != 1 || len(nextInvoices) != 1 {
+		t.Fatalf("invoice counts current=%d next=%d, want 1/1", len(currentInvoices), len(nextInvoices))
+	}
+	issue := postJSON[backend.IssueResult](t, env.Client, env.Server.URL, "/api/invoices/"+strconv.Itoa(currentInvoices[0].ID)+"/issue", map[string]any{
+		"version": currentInvoices[0].Version,
+	})
+	if issue.Number == "" {
+		t.Fatal("expected invoice number")
+	}
+
+	beforeCurrent := getJSON[backend.InvoiceDTO](t, env.Client, env.Server.URL, "/api/invoices/"+strconv.Itoa(currentInvoices[0].ID))
+	beforeNext := getJSON[backend.InvoiceDTO](t, env.Client, env.Server.URL, "/api/invoices/"+strconv.Itoa(nextInvoices[0].ID))
+	if beforeCurrent.Total != 25 || beforeNext.Total != 25 {
+		t.Fatalf("before totals current=%v next=%v, want 25/25", beforeCurrent.Total, beforeNext.Total)
+	}
+
+	updated := putJSON[backend.EnrollmentDTO](t, env.Client, env.Server.URL, "/api/enrollments/"+strconv.Itoa(enr.ID), map[string]any{
+		"version":                 enr.Version,
+		"billingMode":             "per_lesson",
+		"chargeMaterials":         false,
+		"lessonPriceOverride":     0,
+		"subscriptionLessonPrice": 0,
+		"note":                    "",
+	})
+	if updated.ChargeMaterials {
+		t.Fatal("updated chargeMaterials = true, want false")
+	}
+
+	afterCurrent := getJSON[backend.InvoiceDTO](t, env.Client, env.Server.URL, "/api/invoices/"+strconv.Itoa(currentInvoices[0].ID))
+	afterNext := getJSON[backend.InvoiceDTO](t, env.Client, env.Server.URL, "/api/invoices/"+strconv.Itoa(nextInvoices[0].ID))
+	if afterCurrent.Total != 25 {
+		t.Fatalf("current invoice total = %v, want 25", afterCurrent.Total)
+	}
+	if afterNext.Total != 20 {
+		t.Fatalf("next invoice total = %v, want 20", afterNext.Total)
+	}
+	if afterCurrent.Status != beforeCurrent.Status {
+		t.Fatalf("current invoice status = %q, want unchanged %q", afterCurrent.Status, beforeCurrent.Status)
+	}
+
+	nextLines, err := env.Runtime.DB.Ent.InvoiceLine.Query().
+		Where(invoiceline.InvoiceIDEQ(nextInvoices[0].ID)).
+		All(context.Background())
+	if err != nil {
+		t.Fatalf("InvoiceLine.Query next: %v", err)
+	}
+	for _, line := range nextLines {
+		if line.Description == "Mācību materiāli" {
+			t.Fatal("next invoice still has materials line after toggle off")
+		}
+	}
+}
+
+func TestEnrollmentChargeMaterialsAppliesOnNextGenerationWhenFutureDraftMissing(t *testing.T) {
+	env := newTestServer(t)
+	defer env.Close()
+
+	now := time.Now()
+	currentYear, currentMonth := now.Year(), int(now.Month())
+	nextYear, nextMonth := currentYear, currentMonth+1
+	if nextMonth == 13 {
+		nextMonth = 1
+		nextYear++
+	}
+
+	st := postJSON[backend.StudentDTO](t, env.Client, env.Server.URL, "/api/students", map[string]any{"fullName": "Generate Later Student"})
+	course := postJSON[backend.CourseDTO](t, env.Client, env.Server.URL, "/api/courses", map[string]any{
+		"name":              "Generate Later Course",
+		"type":              "group",
+		"lessonPrice":       20,
+		"subscriptionPrice": 0,
+	})
+	enr := postJSON[backend.EnrollmentDTO](t, env.Client, env.Server.URL, "/api/enrollments", map[string]any{
+		"studentId":           st.ID,
+		"courseId":            course.ID,
+		"billingMode":         "per_lesson",
+		"chargeMaterials":     true,
+		"lessonPriceOverride": 0,
+		"note":                "",
+	})
+
+	putJSON[map[string]bool](t, env.Client, env.Server.URL, "/api/attendance", map[string]any{
+		"studentId": st.ID,
+		"courseId":  course.ID,
+		"year":      currentYear,
+		"month":     currentMonth,
+		"hours":     1.0,
+	})
+	putJSON[map[string]bool](t, env.Client, env.Server.URL, "/api/attendance", map[string]any{
+		"studentId": st.ID,
+		"courseId":  course.ID,
+		"year":      nextYear,
+		"month":     nextMonth,
+		"hours":     1.0,
+	})
+	postJSON[map[string]any](t, env.Client, env.Server.URL, "/api/invoices/generate-drafts", map[string]any{
+		"year":  currentYear,
+		"month": currentMonth,
+	})
+
+	currentInvoices := getJSON[[]backend.InvoiceListItem](t, env.Client, env.Server.URL, "/api/invoices?year="+strconv.Itoa(currentYear)+"&month="+strconv.Itoa(currentMonth)+"&status=all")
+	if len(currentInvoices) != 1 {
+		t.Fatalf("current invoice count = %d, want 1", len(currentInvoices))
+	}
+	postJSON[backend.IssueResult](t, env.Client, env.Server.URL, "/api/invoices/"+strconv.Itoa(currentInvoices[0].ID)+"/issue", map[string]any{
+		"version": currentInvoices[0].Version,
+	})
+
+	updated := putJSON[backend.EnrollmentDTO](t, env.Client, env.Server.URL, "/api/enrollments/"+strconv.Itoa(enr.ID), map[string]any{
+		"version":                 enr.Version,
+		"billingMode":             "per_lesson",
+		"chargeMaterials":         false,
+		"lessonPriceOverride":     0,
+		"subscriptionLessonPrice": 0,
+		"note":                    "",
+	})
+	if updated.ChargeMaterials {
+		t.Fatal("updated chargeMaterials = true, want false")
+	}
+
+	nextBeforeGeneration := getJSON[[]backend.InvoiceListItem](t, env.Client, env.Server.URL, "/api/invoices?year="+strconv.Itoa(nextYear)+"&month="+strconv.Itoa(nextMonth)+"&status=all")
+	if len(nextBeforeGeneration) != 0 {
+		t.Fatalf("next invoice count before generation = %d, want 0", len(nextBeforeGeneration))
+	}
+
+	postJSON[map[string]any](t, env.Client, env.Server.URL, "/api/invoices/generate-drafts", map[string]any{
+		"year":  nextYear,
+		"month": nextMonth,
+	})
+
+	nextAfterGeneration := getJSON[[]backend.InvoiceListItem](t, env.Client, env.Server.URL, "/api/invoices?year="+strconv.Itoa(nextYear)+"&month="+strconv.Itoa(nextMonth)+"&status=all")
+	if len(nextAfterGeneration) != 1 {
+		t.Fatalf("next invoice count after generation = %d, want 1", len(nextAfterGeneration))
+	}
+	nextInvoice := getJSON[backend.InvoiceDTO](t, env.Client, env.Server.URL, "/api/invoices/"+strconv.Itoa(nextAfterGeneration[0].ID))
+	if nextInvoice.Total != 20 {
+		t.Fatalf("next invoice total = %v, want 20", nextInvoice.Total)
 	}
 }
 


### PR DESCRIPTION
## Summary
- defer enrollment billing changes to the next month when the current month already has an issued or paid invoice
- rebuild only an existing draft for the resolved target month and leave issued/paid invoices untouched
- add coverage for current draft behavior, deferred next-month rebuilds, delayed generation, and December-to-January rollover

## Verification
- go test ./...
- npm test
- npm run build
- npm run lint